### PR TITLE
Better collapse point for navbar mobile landscape

### DIFF
--- a/shiny_app/www/css/navbar_and_panels.css
+++ b/shiny_app/www/css/navbar_and_panels.css
@@ -54,6 +54,45 @@
 }
 
 
+/* Increase width at which navbar collapses for better viewing on mobile landscape */
+@media (max-width: 991px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin: 7.5px -15px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .navbar-text {
+        float: none;
+        margin: 15px 0;
+    }
+    /* since 3.1.0 */
+    .navbar-collapse.collapse.in {
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
+}
+
 /* notes panel */
 .panel-heading
 {

--- a/shiny_app/www/css/navbar_and_panels.css
+++ b/shiny_app/www/css/navbar_and_panels.css
@@ -54,7 +54,11 @@
 }
 
 
-/* Increase width at which navbar collapses for better viewing on mobile landscape */
+/*
+  Increase width at which navbar collapses for better viewing on mobile landscape
+  Change max-width argument to a different number of pixels to change the float breakpoint
+  https://stackoverflow.com/questions/27092929/where-to-edit-bootstrap-grid-float-breakpoint
+*/
 @media (max-width: 991px) {
     .navbar-header {
         float: none;
@@ -93,7 +97,7 @@
     }
 }
 
-/* notes panel */
+/* Notes panel */
 .panel-heading
 {
   background-color: var(--phs-blue-10) !Important;


### PR DESCRIPTION
Change the point at which the navbar collapses so that on landscape on mobile it is collapsed and you can view the content better.