### PR TITLE
Extra tweaks cm

### DIFF
--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -192,7 +192,7 @@ ui <- fluidPage(
                             tabPanel(title = "Rhinovirus",
                                      value = "rhinovirus",
                                      column(12, source(file.path("indicators/respiratory_mem/rhinovirus/rhinovirus_mem_ui.R"), local = TRUE)$value)),
-                            tabPanel(title = "Seasonal Coronaviruses (not COVID-19)",
+                            tabPanel(title = "Other seasonal coronaviruses",
                                      value = "seasonal_coronavirus",
                                      column(12, source(file.path("indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_ui.R"), local = TRUE)$value))
                             # tabPanel(title = "Other respiratory pathogens",

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
@@ -80,7 +80,7 @@ tagList(
                            ),
 
                            tagList(h2("Number of acute COVID-19 admissions to hospital by ethnicity"),
-                                   h4(strong("These data will next be updated in August 2023.")),
+                                   h4(strong("These data will next be updated in November 2023.")),
                                    tabBox(width = NULL, type = "pills",
                                           tabPanel("Plot",
                                                    tagList(

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
@@ -10,7 +10,8 @@ tagList(
                   tabPanel("Acute hospital admissions",
                            tagList(h2("Number of acute COVID-19 admissions to hospital"),
                                    tags$div(class = "headline",
-                                            h3("Weekly totals from last three weeks"),
+                                            linebreaks(1),
+                                            #h3("Weekly totals from last three weeks"),
 
                                             valueBox(value = glue("{admissions_headlines[[1]]}*"),
                                                      subtitle = glue("Week ending {names(admissions_headlines)[[1]]}"),
@@ -78,6 +79,26 @@ tagList(
 
                            ),
 
+                           tagList(h2("Number of acute COVID-19 admissions to hospital by ethnicity"),
+                                   h4(strong("These data will next be updated in August 2023.")),
+                                   tabBox(width = NULL, type = "pills",
+                                          tabPanel("Plot",
+                                                   tagList(
+                                                     linebreaks(1),
+                                                     altTextUI("hospital_admissions_ethnicity_modal"),
+                                                     withNavySpinner(
+                                                       plotlyOutput("hospital_admissions_ethnicity_plot")
+                                                     )
+                                                   )
+                                          ),
+                                          tabPanel("Data",
+                                                   withNavySpinner(
+                                                     dataTableOutput("hospital_admissions_ethnicity_table")
+                                                   )
+                                          ) # tabpanel
+                                   ) # tabbox
+                           ),
+
                            tagList(h2("Length of stay of acute COVID-19 hospital admissions"),
                                    tags$div(class = "headline",
                                             h3(glue("Median length of stay of acute COVID-19 hospital admissions for 4 week period {los_date_start %>% format('%d %b %y')} to {los_date_end%>% format('%d %b %y')} ")),
@@ -126,25 +147,7 @@ tagList(
 
                            ),
 
-                           tagList(h2("Number of acute COVID-19 admissions to hospital by ethnicity"),
-                                   h4(strong("These data will next be updated in August 2023.")),
-                           tabBox(width = NULL, type = "pills",
-                                  tabPanel("Plot",
-                                           tagList(
-                                             linebreaks(1),
-                                             altTextUI("hospital_admissions_ethnicity_modal"),
-                                             withNavySpinner(
-                                               plotlyOutput("hospital_admissions_ethnicity_plot")
-                                               )
-                                          )
-                                              ),
-                                  tabPanel("Data",
-                                           withNavySpinner(
-                                               dataTableOutput("hospital_admissions_ethnicity_table")
-                                               )
-                                  ) # tabpanel
-                                           ) # tabbox
-                           ) # taglist
+ # taglist
   ),
   # Padding out the bottom of the page
   fluidRow(height="200px", width=12, linebreaks(5))

--- a/shiny_app/indicators/respiratory_mem/respiratory_mem_functions.R
+++ b/shiny_app/indicators/respiratory_mem/respiratory_mem_functions.R
@@ -653,11 +653,11 @@ data %<>%
 
 
     # Adding vertical lines for notes on chart
-    add_lines_and_notes(dataframe = data,
-                        ycol = "Influenza",
-                        xs= c("2023-10-08"),
-                        notes=c("Season 23/24"),
-                        colors=c(phs_colours("phs-teal"))) %>%
+    # add_lines_and_notes(dataframe = data,
+    #                     ycol = "Influenza",
+    #                     xs= c("2023-10-08"),
+    #                     notes=c("Season 23/24"),
+    #                     colors=c(phs_colours("phs-teal"))) %>%
 
 
     layout(margin = list(b = 80, t = 5),

--- a/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_ui.R
+++ b/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_ui.R
@@ -1,18 +1,18 @@
 tagList(
   fluidRow(width = 12,
-           
+
            metadataButtonUI("respiratory_seasonal_coronavirus_mem"),
            linebreaks(1),
-           h1("Seasonal Coronaviruses (not COVID-19)"),
-           p("Seasonal Coronaviruses are a group of viruses that typically cause mild to moderate",
+           h1("Other seasonal coronaviruses"),
+           p("Seasonal Coronaviruses (not COVID-19) are a group of viruses that typically cause mild to moderate",
              "upper respiratory tract infections, such as the common cold, but can cause lower-respiratory",
              "tract illnesses such as pneumonia and bronchitis. Infection can occur in people of all ages.",
              "Seasonal coronaviruses have an annual seasonality and typically circulate in the winter months."),
            linebreaks(1)),
-  
+
   fluidRow(width = 12,
            tagList(h2("Seasonal Coronavirus incidence rate per 100,000 population in Scotland"))),
-  
+
   fluidRow(
     tabBox(width = NULL,
            type = "pills",
@@ -26,14 +26,14 @@ tagList(
                             withNavySpinner(dataTableOutput("seasonal_coronavirus_mem_table"))
                     ) # tagList
            ) # tabPanel
-           
+
     ), # tabBox
     linebreaks(1)
   ), # fluidRow
-  
+
   fluidRow(width = 12,
            tagList(h2("Seasonal Coronavirus incidence rate per 100,000 population by NHS Health Board"))),
-  
+
   fluidRow(
     tabBox(width = NULL,
            type = "pills",
@@ -47,15 +47,15 @@ tagList(
                             withNavySpinner(dataTableOutput("seasonal_coronavirus_mem_hb_table"))
                     ) # tagList
            ) # tabPanel
-           
+
     ), # tabBox
     linebreaks(1)
   ), # fluidRow
-  
-  
+
+
   fluidRow(width = 12,
            tagList(h2("Seasonal Coronavirus incidence rate per 100,000 population by age group"))),
-  
+
   fluidRow(
     tabBox(width = NULL,
            type = "pills",
@@ -69,9 +69,9 @@ tagList(
                             withNavySpinner(dataTableOutput("seasonal_coronavirus_mem_age_table"))
                     ) # tagList
            ) # tabPanel
-           
+
     ), # tabBox
     linebreaks(1)
   )#, # fluidRow
-  
+
 )


### PR DESCRIPTION
- Remove the season line from the hospital admissions chart on at a glance

- covid admissions - move ethnicity next to SIMD if possible
- remove title from hos adm summary box
- Rename seasonal coronaviruses (not covid-19) to "Other seasonal coronaviruses" for the left hand panel