### PR TITLE
Mem line plot fixes

### DIFF
--- a/shiny_app/indicators/respiratory_mem/adenovirus/adenovirus_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/adenovirus/adenovirus_mem_server.R
@@ -35,20 +35,28 @@ adenovirus_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Pathogen == "Adenovirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Adenovirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct()
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Pathogen == "Adenovirus") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Adenovirus") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct()
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
 
 
@@ -60,8 +68,8 @@ altTextServer("adenovirus_mem_modal",
                                        #"The first ISO week is the first week of the year (in January) and the 52nd ISO week is the last week of the year."),
                                 tags$li("The y axis shows the rate of adenovirus infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for adenovirus based on MEM thresholds are represented by different coloured panels on the plot. ",
                                              "The activity levels and MEM thresholds for adenovirus are: ",
                                              "Baseline (< ", adenovirus_low_threshold, "), ",
@@ -73,7 +81,7 @@ altTextServer("adenovirus_mem_modal",
 altTextServer("adenovirus_mem_hb_modal",
               title = "Adenovirus incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of adenovirus infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 #"The first ISO week is the first week of the year (in January) and the 52nd ISO week is the last week of the year."),
@@ -88,7 +96,7 @@ altTextServer("adenovirus_mem_hb_modal",
 altTextServer("adenovirus_mem_age_modal",
               title = "Adenovirus incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of adenovirus infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -103,6 +111,7 @@ altTextServer("adenovirus_mem_age_modal",
 output$adenovirus_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Adenovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -118,6 +127,7 @@ output$adenovirus_mem_table <- renderDataTable({
 # adenovirus MEM by HB table
 output$adenovirus_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
+    filter(Season %in% seasons) %>%
     filter(Pathogen == "Adenovirus") %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
@@ -136,6 +146,7 @@ output$adenovirus_mem_hb_table <- renderDataTable({
 # adenovirus MEM by Age table
 output$adenovirus_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
+    filter(Season %in% seasons) %>%
     filter(Pathogen == "Adenovirus") %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%

--- a/shiny_app/indicators/respiratory_mem/adenovirus/adenovirus_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/adenovirus/adenovirus_mem_server.R
@@ -52,7 +52,8 @@ adenovirus_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>%
+  filter(Pathogen == "Adenovirus") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/hmpv/hmpv_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/hmpv/hmpv_mem_server.R
@@ -52,7 +52,8 @@ hmpv_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>% 
+  filter(Pathogen == "Human Metapneumovirus") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/hmpv/hmpv_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/hmpv/hmpv_mem_server.R
@@ -35,20 +35,28 @@ hmpv_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>% 
+#   filter(Pathogen == "Human Metapneumovirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>% 
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Human Metapneumovirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct()
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>% 
-  filter(Pathogen == "Human Metapneumovirus") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>% 
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Human Metapneumovirus") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct()
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
 
 
@@ -59,8 +67,8 @@ altTextServer("hmpv_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of influenza infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for HMPV based on MEM thresholds are represented by different coloured panels on the plot. ",
                                         "The activity levels and MEM thresholds for HMPV are: ",
                                         "Baseline (< ", hmpv_low_threshold, "), ",
@@ -72,7 +80,7 @@ altTextServer("hmpv_mem_modal",
 altTextServer("hmpv_mem_hb_modal",
               title = "HMPV incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of HMPV infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -86,7 +94,7 @@ altTextServer("hmpv_mem_hb_modal",
 altTextServer("hmpv_mem_age_modal",
               title = "HMPV incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of HMPV infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -101,6 +109,7 @@ altTextServer("hmpv_mem_age_modal",
 output$hmpv_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Human Metapneumovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -117,6 +126,7 @@ output$hmpv_mem_table <- renderDataTable({
 output$hmpv_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Human Metapneumovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -135,6 +145,7 @@ output$hmpv_mem_hb_table <- renderDataTable({
 output$hmpv_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Human Metapneumovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_mem_server.R
@@ -52,7 +52,8 @@ influenza_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>%
+  filter(Pathogen == "Influenza") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_mem_server.R
@@ -35,21 +35,30 @@ influenza_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Pathogen == "Influenza") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Influenza") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct()
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Pathogen == "Influenza") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Influenza") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct()
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("influenza_mem_modal",
@@ -59,8 +68,8 @@ altTextServer("influenza_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of influenza infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for influenza based on MEM thresholds are represented by different coloured panels on the plot. ",
                                         "The activity levels and MEM thresholds for influenza are: ",
                                         "Baseline (< ", influenza_low_threshold, "), ",
@@ -72,7 +81,7 @@ altTextServer("influenza_mem_modal",
 altTextServer("influenza_mem_hb_modal",
               title = "Influenza incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of influenza infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -86,7 +95,7 @@ altTextServer("influenza_mem_hb_modal",
 altTextServer("influenza_mem_age_modal",
               title = "Influenza incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of influenza infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -101,6 +110,7 @@ altTextServer("influenza_mem_age_modal",
 output$influenza_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Influenza") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -117,6 +127,7 @@ output$influenza_mem_table <- renderDataTable({
 output$influenza_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Influenza") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -135,6 +146,7 @@ output$influenza_mem_hb_table <- renderDataTable({
 output$influenza_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Influenza") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/respiratory_mem/mycoplasma_pneumoniae/mycoplasma_pneumoniae_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/mycoplasma_pneumoniae/mycoplasma_pneumoniae_mem_server.R
@@ -35,21 +35,30 @@ mycoplasma_pneumoniae_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot 
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Pathogen == "Mycoplasma Pneumoniae") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Mycoplasma Pneumoniae") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct()
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Pathogen == "Mycoplasma Pneumoniae") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Mycoplasma Pneumoniae") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct()
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("mycoplasma_pneumoniae_mem_modal",
@@ -59,8 +68,8 @@ altTextServer("mycoplasma_pneumoniae_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of mycoplasma pneumoniae infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for mycoplasma pneumoniae based on MEM thresholds are represented by different coloured panels on the plot. ",
                                              "The activity levels and MEM thresholds for mycoplasma pneumoniae are: ",
                                              "Baseline (< ", mycoplasma_pneumoniae_low_threshold, "), ",
@@ -72,7 +81,7 @@ altTextServer("mycoplasma_pneumoniae_mem_modal",
 altTextServer("mycoplasma_pneumoniae_mem_hb_modal",
               title = "Mycoplasma pneumoniae incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of mycoplasma pneumoniae infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -86,7 +95,7 @@ altTextServer("mycoplasma_pneumoniae_mem_hb_modal",
 altTextServer("mycoplasma_pneumoniae_mem_age_modal",
               title = "Mycoplasma pneumoniae incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of mycoplasma pneumoniae infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -101,6 +110,7 @@ altTextServer("mycoplasma_pneumoniae_mem_age_modal",
 output$mycoplasma_pneumoniae_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Mycoplasma Pneumoniae") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -117,6 +127,7 @@ output$mycoplasma_pneumoniae_mem_table <- renderDataTable({
 output$mycoplasma_pneumoniae_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Mycoplasma Pneumoniae") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -135,6 +146,7 @@ output$mycoplasma_pneumoniae_mem_hb_table <- renderDataTable({
 output$mycoplasma_pneumoniae_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Mycoplasma Pneumoniae") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/respiratory_mem/mycoplasma_pneumoniae/mycoplasma_pneumoniae_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/mycoplasma_pneumoniae/mycoplasma_pneumoniae_mem_server.R
@@ -52,7 +52,8 @@ mycoplasma_pneumoniae_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot 
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>%
+  filter(Pathogen == "Mycoplasma Pneumoniae") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/parainfluenza/parainfluenza_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/parainfluenza/parainfluenza_mem_server.R
@@ -34,21 +34,30 @@ parainfluenza_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>% 
+#   filter(Pathogen == "Parainfluenza Virus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Parainfluenza Virus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct()
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>% 
-  filter(Pathogen == "Parainfluenza Virus") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Parainfluenza Virus") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct()
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("parainfluenza_mem_modal",
@@ -58,8 +67,8 @@ altTextServer("parainfluenza_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of parainfluenza infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for parainfluenza based on MEM thresholds are represented by different coloured panels on the plot. ",
                                              "The activity levels and MEM thresholds for parainfluenza are: ",
                                              "Baseline (< ", parainfluenza_low_threshold, "), ", 
@@ -71,7 +80,7 @@ altTextServer("parainfluenza_mem_modal",
 altTextServer("parainfluenza_mem_hb_modal",
               title = "Parainfluenza incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of parainfluenza infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ", 
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -85,7 +94,7 @@ altTextServer("parainfluenza_mem_hb_modal",
 altTextServer("parainfluenza_mem_age_modal",
               title = "Parainfluenza incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of parainfluenza infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ", 
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -100,6 +109,7 @@ altTextServer("parainfluenza_mem_age_modal",
 output$parainfluenza_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Parainfluenza Virus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -116,6 +126,7 @@ output$parainfluenza_mem_table <- renderDataTable({
 output$parainfluenza_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Parainfluenza Virus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -134,6 +145,7 @@ output$parainfluenza_mem_hb_table <- renderDataTable({
 output$parainfluenza_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Parainfluenza Virus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/respiratory_mem/parainfluenza/parainfluenza_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/parainfluenza/parainfluenza_mem_server.R
@@ -51,7 +51,8 @@ parainfluenza_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>% 
+  filter(Pathogen == "Parainfluenza Virus") %>% 
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/respiratory_mem_functions.R
+++ b/shiny_app/indicators/respiratory_mem/respiratory_mem_functions.R
@@ -30,21 +30,28 @@ create_mem_linechart <- function(data,
     rename(Value = value_variable) %>%
     mutate(Value = round_half_up(Value, rate_dp))
 
-  # If seasons not supplied, use two most recent seasons
-  if(is.null(seasons)){
-    seasons_1 <- data %>%
-      select(Season) %>%
-      arrange(Season) %>%
-      distinct() %>%
-      tail(6)
-    seasons_2 <- data %>%
-      filter(Season == "2010/2011") %>%
-      select(Season) %>%
-      arrange(Season) %>%
-      distinct()
-    seasons <- bind_rows(seasons_2, seasons_1)
-    seasons <- seasons$Season
-  }
+  # # If seasons not supplied, use two most recent seasons
+  # if(is.null(seasons)){
+  #   seasons_1 <- data %>%
+  #     select(Season) %>%
+  #     arrange(Season) %>%
+  #     distinct() %>%
+  #     tail(6)
+  #   seasons_2 <- data %>%
+  #     filter(Season == "2010/2011") %>%
+  #     select(Season) %>%
+  #     arrange(Season) %>%
+  #     distinct()
+  #   seasons <- bind_rows(seasons_2, seasons_1)
+  #   seasons <- seasons$Season
+  # }
+  
+  seasons <- data %>%
+    select(Season) %>%
+    arrange(Season) %>%
+    distinct() %>%
+    tail(6)
+  seasons <- seasons$Season
 
   # Wrangle data
   data = data %>%

--- a/shiny_app/indicators/respiratory_mem/respiratory_mem_functions.R
+++ b/shiny_app/indicators/respiratory_mem/respiratory_mem_functions.R
@@ -70,6 +70,7 @@ create_mem_linechart <- function(data,
   #xaxis_plots[["rangeslider"]] <- list(type = "date")
   yaxis_plots[["fixedrange"]] <- FALSE
   yaxis_plots[["title"]] <- y_axis_title
+  yaxis_plots[["tickformat"]] <- ""
 
   xaxis_plots[["showgrid"]] <- FALSE
   yaxis_plots[["showgrid"]] <- FALSE

--- a/shiny_app/indicators/respiratory_mem/rhinovirus/rhinovirus_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/rhinovirus/rhinovirus_mem_server.R
@@ -35,21 +35,30 @@ rhinovirus_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Pathogen == "Rhinovirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Rhinovirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() 
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Pathogen == "Rhinovirus") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Rhinovirus") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct() 
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("rhinovirus_mem_modal",
@@ -59,8 +68,8 @@ altTextServer("rhinovirus_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of rhinovirus infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for rhinovirus based on MEM thresholds are represented by different coloured panels on the plot. ",
                                         "The activity levels and MEM thresholds for rhinovirus are: ",
                                         "Baseline (< ", rhinovirus_low_threshold, "), ",
@@ -72,7 +81,7 @@ altTextServer("rhinovirus_mem_modal",
 altTextServer("rhinovirus_mem_hb_modal",
               title = "Rhinovirus incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of rhinovirus infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -86,7 +95,7 @@ altTextServer("rhinovirus_mem_hb_modal",
 altTextServer("rhinovirus_mem_age_modal",
               title = "Rhinovirus incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of rhinovirus infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -101,6 +110,7 @@ altTextServer("rhinovirus_mem_age_modal",
 output$rhinovirus_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Rhinovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -117,6 +127,7 @@ output$rhinovirus_mem_table <- renderDataTable({
 output$rhinovirus_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Rhinovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -135,6 +146,7 @@ output$rhinovirus_mem_hb_table <- renderDataTable({
 output$rhinovirus_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Rhinovirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/respiratory_mem/rhinovirus/rhinovirus_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/rhinovirus/rhinovirus_mem_server.R
@@ -52,7 +52,8 @@ rhinovirus_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>%
+  filter(Pathogen == "Rhinovirus") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_mem_server.R
@@ -35,21 +35,30 @@ rsv_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Pathogen == "Respiratory Syncytial Virus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Respiratory Syncytial Virus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() 
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Pathogen == "Respiratory Syncytial Virus") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Respiratory Syncytial Virus") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct() 
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("rsv_mem_modal",
@@ -59,8 +68,8 @@ altTextServer("rsv_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of rsv infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for RSV based on MEM thresholds are represented by different coloured panels on the plot. ",
                                         "The activity levels and MEM thresholds for HMPV are: ",
                                         "Baseline (< ", rsv_low_threshold, "), ",
@@ -72,7 +81,7 @@ altTextServer("rsv_mem_modal",
 altTextServer("rsv_mem_hb_modal",
               title = "RSV incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of RSV infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -86,7 +95,7 @@ altTextServer("rsv_mem_hb_modal",
 altTextServer("rsv_mem_age_modal",
               title = "RSV incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of RSV infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -101,6 +110,7 @@ altTextServer("rsv_mem_age_modal",
 output$rsv_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Respiratory Syncytial Virus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -117,6 +127,7 @@ output$rsv_mem_table <- renderDataTable({
 output$rsv_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Respiratory Syncytial Virus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -135,6 +146,7 @@ output$rsv_mem_hb_table <- renderDataTable({
 output$rsv_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Respiratory Syncytial Virus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_mem_server.R
@@ -52,7 +52,8 @@ rsv_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>%
+  filter(Pathogen == "Respiratory Syncytial Virus") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_server.R
@@ -52,7 +52,8 @@ seasonal_coronavirus_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_Pathogens_MEM_Scot %>%
+  filter(Pathogen == "Coronavirus") %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_server.R
+++ b/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_mem_server.R
@@ -35,21 +35,30 @@ seasonal_coronavirus_extraordinary_threshold <- Respiratory_Pathogens_MEM_Scot %
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Pathogen == "Coronavirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   filter(Pathogen == "Coronavirus") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() 
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Pathogen == "Coronavirus") %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_Pathogens_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  filter(Pathogen == "Coronavirus") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct() 
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("seasonal_coronavirus_mem_modal",
@@ -59,8 +68,8 @@ altTextServer("seasonal_coronavirus_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of seasonal coronavirus infection per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for seasonal coronavirus based on MEM thresholds are represented by different coloured panels on the plot. ",
                                              "The activity levels and MEM thresholds for seasonal coronavirus are: ",
                                              "Baseline (< ", seasonal_coronavirus_low_threshold, "), ",
@@ -72,7 +81,7 @@ altTextServer("seasonal_coronavirus_mem_modal",
 altTextServer("seasonal_coronavirus_mem_hb_modal",
               title = "Seasonal coronavirus incidence rate per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of seasonal coronavirus infection per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -86,7 +95,7 @@ altTextServer("seasonal_coronavirus_mem_hb_modal",
 altTextServer("seasonal_coronavirus_mem_age_modal",
               title = "Seasonal coronavirus incidence rate per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of seasonal coronavirus infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -101,6 +110,7 @@ altTextServer("seasonal_coronavirus_mem_age_modal",
 output$seasonal_coronavirus_mem_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Scot %>%
     filter(Pathogen == "Coronavirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -117,6 +127,7 @@ output$seasonal_coronavirus_mem_table <- renderDataTable({
 output$seasonal_coronavirus_mem_hb_table <- renderDataTable({
   Respiratory_Pathogens_MEM_HB %>%
     filter(Pathogen == "Coronavirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -135,6 +146,7 @@ output$seasonal_coronavirus_mem_hb_table <- renderDataTable({
 output$seasonal_coronavirus_mem_age_table <- renderDataTable({
   Respiratory_Pathogens_MEM_Age %>%
     filter(Pathogen == "Coronavirus") %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/syndromic_surveillance/gp/gp_server.R
+++ b/shiny_app/indicators/syndromic_surveillance/gp/gp_server.R
@@ -30,19 +30,28 @@ gp_extraordinary_threshold <- Respiratory_GPILI_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_GPILI_MEM_Scot %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_GPILI_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() 
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_GPILI_MEM_Scot %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_GPILI_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct() 
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("gp_mem_modal",
@@ -52,8 +61,8 @@ altTextServer("gp_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the rate of GP consultations for ILI per 100,000 population."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for GP consultations for ILI based on MEM thresholds are represented by different coloured panels on the plot. ",
                                              "The activity levels and MEM thresholds for GP consultations are: ",
                                              "Baseline (< ", gp_low_threshold, "), ",
@@ -65,7 +74,7 @@ altTextServer("gp_mem_modal",
 altTextServer("gp_mem_hb_modal",
               title = "GP consultation rates for influenza-like illness (ILI) per 100,000 population by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of GP consultations for ILI per 100,000 population by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -79,7 +88,7 @@ altTextServer("gp_mem_hb_modal",
 altTextServer("gp_mem_age_modal",
               title = "GP consultation rates for influenza-like illness (ILI) per 100,000 population by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the rate of GP consultations for ILI infection per 100,000 population by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -93,6 +102,7 @@ altTextServer("gp_mem_age_modal",
 # GP MEM table
 output$gp_mem_table <- renderDataTable({
   Respiratory_GPILI_MEM_Scot %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -108,6 +118,7 @@ output$gp_mem_table <- renderDataTable({
 # GP MEM by HB table
 output$gp_mem_hb_table <- renderDataTable({
   Respiratory_GPILI_MEM_HB %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -125,6 +136,7 @@ output$gp_mem_hb_table <- renderDataTable({
 # GP MEM by Age table
 output$gp_mem_age_table <- renderDataTable({
   Respiratory_GPILI_MEM_Age %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, RatePer100000, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/syndromic_surveillance/gp/gp_server.R
+++ b/shiny_app/indicators/syndromic_surveillance/gp/gp_server.R
@@ -45,7 +45,7 @@ gp_extraordinary_threshold <- Respiratory_GPILI_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_GPILI_MEM_Scot %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/indicators/syndromic_surveillance/nhs24/nhs24_server.R
+++ b/shiny_app/indicators/syndromic_surveillance/nhs24/nhs24_server.R
@@ -30,19 +30,28 @@ nhs24_extraordinary_threshold <- Respiratory_NHS24_MEM_Scot %>%
   .$ExtraordinaryThreshold %>%
   round_half_up(2)
 
+# # Get seasons used in line chart
+# seasons_1 <- Respiratory_NHS24_MEM_Scot %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() %>%
+#   tail(6)
+# seasons_2 <- Respiratory_NHS24_MEM_Scot %>%
+#   filter(Season == "2010/2011") %>%
+#   select(Season) %>%
+#   arrange(Season) %>%
+#   distinct() 
+# seasons <- bind_rows(seasons_2, seasons_1)
+# seasons <- seasons$Season
+
 # Get seasons used in line chart
-seasons_1 <- Respiratory_NHS24_MEM_Scot %>%
+seasons <- data %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%
   tail(6)
-seasons_2 <- Respiratory_NHS24_MEM_Scot %>%
-  filter(Season == "2010/2011") %>%
-  select(Season) %>%
-  arrange(Season) %>%
-  distinct() 
-seasons <- bind_rows(seasons_2, seasons_1)
 seasons <- seasons$Season
+
 
 
 altTextServer("nhs24_mem_modal",
@@ -52,8 +61,8 @@ altTextServer("nhs24_mem_modal",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the percentage of NHS24 calls for respiratory symptoms."),
                                 tags$li(glue("There is a trace for each of the following seasons: ", seasons[1], ", ",
-                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", ",
-                                             seasons[6], ", and ", seasons[7], ".")),
+                                             seasons[2], ", ", seasons[3], ", ", seasons[4], ", ", seasons[5], ", and ",
+                                             seasons[6], ".")),
                                 tags$li(glue("Activity levels for NHS24 calls based on MEM thresholds are represented by different coloured panels on the plot. ",
                                              "The activity levels and MEM thresholds for NHS24 calls are: ",
                                              "Baseline (< ", nhs24_low_threshold, "), ",
@@ -65,7 +74,7 @@ altTextServer("nhs24_mem_modal",
 altTextServer("nhs24_mem_hb_modal",
               title = "Percentage of NHS24 calls for respiratory symptoms by NHS Health Board",
               content = tags$ul(tags$li(glue("This is a plot showing the percentage of NHS24 calls for respiratory symptoms by NHS Health Board for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the NHS Health Board."),
@@ -79,7 +88,7 @@ altTextServer("nhs24_mem_hb_modal",
 altTextServer("nhs24_mem_age_modal",
               title = "Percentage of NHS24 calls for respiratory symptoms by age group",
               content = tags$ul(tags$li(glue("This is a plot showing the percentage of NHS24 calls for respiratory symptoms by age group for seasons ",
-                                             seasons[6], " and ", seasons[7], ".")),
+                                             seasons[5], " and ", seasons[6], ".")),
                                 tags$li("The x axis shows the ISO week of sample, from week 40 to week 39. ",
                                         "Week 40 is typically the start of October and when the winter respiratory season starts."),
                                 tags$li("The y axis shows the age group."),
@@ -93,6 +102,7 @@ altTextServer("nhs24_mem_age_modal",
 # NHS24 MEM table
 output$nhs24_mem_table <- renderDataTable({
   Respiratory_NHS24_MEM_Scot %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, Percentage, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -108,6 +118,7 @@ output$nhs24_mem_table <- renderDataTable({
 # NHS24 MEM by HB table
 output$nhs24_mem_hb_table <- renderDataTable({
   Respiratory_NHS24_MEM_HB %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, HBName, Percentage, ActivityLevel) %>%
     mutate(Season = factor(Season),
@@ -125,6 +136,7 @@ output$nhs24_mem_hb_table <- renderDataTable({
 # NHS24 MEM by Age table
 output$nhs24_mem_age_table <- renderDataTable({
   Respiratory_NHS24_MEM_Age %>%
+    filter(Season %in% seasons) %>%
     arrange(desc(WeekEnding)) %>%
     select(Season, ISOWeek, AgeGroup, Percentage, ActivityLevel) %>%
     mutate(Season = factor(Season),

--- a/shiny_app/indicators/syndromic_surveillance/nhs24/nhs24_server.R
+++ b/shiny_app/indicators/syndromic_surveillance/nhs24/nhs24_server.R
@@ -45,7 +45,7 @@ nhs24_extraordinary_threshold <- Respiratory_NHS24_MEM_Scot %>%
 # seasons <- seasons$Season
 
 # Get seasons used in line chart
-seasons <- data %>%
+seasons <- Respiratory_NHS24_MEM_Scot %>%
   select(Season) %>%
   arrange(Season) %>%
   distinct() %>%

--- a/shiny_app/setup.R
+++ b/shiny_app/setup.R
@@ -171,7 +171,9 @@ activity_levels <- c("Baseline", "Low", "Moderate", "High", "Extraordinary")
 activity_level_colours <- c("#01A148", "#FFDE17", "#F36523", "#ED1D24", "#7D4192")
 
 # Colours for lines on line chart
-mem_line_colours <- c("#010101", "#A35000", "#00FF1A", "#004785","#00a2e5",
+# mem_line_colours <- c("#010101", "#A35000", "#00FF1A", "#004785","#00a2e5",
+#                       "#376C31", "#FF0000")
+mem_line_colours <- c("#A35000", "#00FF1A", "#004785","#00a2e5",
                       "#376C31", "#FF0000")
 
 # Colours for lines on summary admissions line chart


### PR DESCRIPTION
Removed 2010/11 from MEM chart lines and only kept last six seasons of data in data tables.
Updated plot descriptions to reference the correct seasons accordingly.
Fixed issue with y-axis on MEM line charts.
