### PR TITLE
Remove data download section that wrangles the weekly occupancy file.…

### DIFF
--- a/Dashboard Data Transfer/Transfer Scripts/transfer_occupancy.R
+++ b/Dashboard Data Transfer/Transfer Scripts/transfer_occupancy.R
@@ -53,21 +53,21 @@ g_occupancy_hospital_scotland <- g_occupancy_hospital_healthboard %>%
 
 
 ###############
-# g_occupancy_hospital <- bind_rows(g_occupancy_hospital_healthboard, g_occupancy_hospital_scotland) %>%
-#   group_by(HealthBoard) %>%
-#   mutate(SevenDayAverage = round_half_up(zoo::rollmean(HospitalOccupancy, k = 7, fill = NA, align="right"),0),
-#          SevenDayAverageQF = ifelse(is.na(SevenDayAverage), ":", ""),
-#          SevenDayAverageQF = ifelse(Date <= 20200912 , "z", SevenDayAverageQF),
-#          HospitalOccupancyQF = ifelse(is.na(HospitalOccupancy), ":", "")) %>%
-#   ungroup() %>%
-#   arrange(Date) %>%
-#   select(Date, HealthBoard, HealthBoardQF, HospitalOccupancy, HospitalOccupancyQF, SevenDayAverage, SevenDayAverageQF) %>%
-#   mutate(HealthBoard = ifelse(substr(HealthBoard,1,1)=="Z", "Other", HealthBoard),
-#          HealthBoard = unlist(hblookup[HealthBoard]),
-#          HealthBoardQF = ifelse(HealthBoard == "", ":", HealthBoardQF)) %>%
-#   filter(HealthBoard == "S92000003") #for disclosure reasons temporarily filtering for Scotland only
-# 
-# write.csv(g_occupancy_hospital, glue(output_folder, "Occupancy_Hospital.csv"), row.names = FALSE)
+g_occupancy_hospital <- bind_rows(g_occupancy_hospital_healthboard, g_occupancy_hospital_scotland) %>%
+  group_by(HealthBoard) %>%
+  mutate(SevenDayAverage = round_half_up(zoo::rollmean(HospitalOccupancy, k = 7, fill = NA, align="right"),0),
+         SevenDayAverageQF = ifelse(is.na(SevenDayAverage), ":", ""),
+         SevenDayAverageQF = ifelse(Date <= 20200912 , "z", SevenDayAverageQF),
+         HospitalOccupancyQF = ifelse(is.na(HospitalOccupancy), ":", "")) %>%
+  ungroup() %>%
+  arrange(Date) %>%
+  select(Date, HealthBoard, HealthBoardQF, HospitalOccupancy, HospitalOccupancyQF, SevenDayAverage, SevenDayAverageQF) %>%
+  mutate(HealthBoard = ifelse(substr(HealthBoard,1,1)=="Z", "Other", HealthBoard),
+         HealthBoard = unlist(hblookup[HealthBoard]),
+         HealthBoardQF = ifelse(HealthBoard == "", ":", HealthBoardQF)) %>%
+  filter(HealthBoard == "S92000003") #for disclosure reasons temporarily filtering for Scotland only
+
+write.csv(g_occupancy_hospital, glue(output_folder, "Occupancy_Hospital.csv"), row.names = FALSE)
 
 
 
@@ -86,7 +86,7 @@ g_occupancy_hospital_hb <- bind_rows(g_occupancy_hospital_healthboard, g_occupan
          #HealthBoard = unlist(hblookup[HealthBoard]),
          HealthBoardQF = ifelse(HealthBoard == "", ":", HealthBoardQF))
 
-#write.csv(g_occupancy_hospital_hb, glue(output_folder, "Occupancy_Hospital_HB.csv"), row.names = FALSE)
+write.csv(g_occupancy_hospital_hb, glue(output_folder, "Occupancy_Hospital_HB.csv"), row.names = FALSE)
 
 # new section weekly hospital occupancy
 g_occupancy_weekly_hb <- g_occupancy_hospital_hb %>%

--- a/shiny_app/indicators/download/download_server.R
+++ b/shiny_app/indicators/download/download_server.R
@@ -1,14 +1,14 @@
 # Data download choices
 
-Occupancy_Weekly_Hospital_HB<-Occupancy_Weekly_Hospital_HB %>% 
-  filter(HealthBoardQF== "d") %>% #filters for Scotland values
-  select(WeekEnding=WeekEnding_od,
-         HealthBoardOfTreatment=HealthBoardName, 
-         HealthBoardOfTreatmentQF=HealthBoardQF,
-         InpatientsAsAtLastSunday=HospitalOccupancy, 
-         InpatientsAsAtLastSundayQF=HospitalOccupancyQF, 
-         InpatientsSevenDayAverage= SevenDayAverage, 
-         InpatientsSevenDayAverageQF=SevenDayAverageQF)
+# Occupancy_Weekly_Hospital_HB<-Occupancy_Weekly_Hospital_HB %>% 
+#   filter(HealthBoardQF== "d") %>% #filters for Scotland values
+#   select(WeekEnding=WeekEnding_od,
+#          HealthBoardOfTreatment=HealthBoardName, 
+#          HealthBoardOfTreatmentQF=HealthBoardQF,
+#          InpatientsAsAtLastSunday=HospitalOccupancy, 
+#          InpatientsAsAtLastSundayQF=HospitalOccupancyQF, 
+#          InpatientsSevenDayAverage= SevenDayAverage, 
+#          InpatientsSevenDayAverageQF=SevenDayAverageQF)
 
 
 metadataButtonServer(id="download",


### PR DESCRIPTION
… This should allow occupancy charts and tables to appear in the dashboard.

Removed hash tags in transfer_occupancy that stopped  the production of daily occupancy files