### PR TITLE
Commented out all the data tables showing breakdown of admissions

### DIFF
--- a/shiny_app/deployment/app_deployment.R
+++ b/shiny_app/deployment/app_deployment.R
@@ -5,7 +5,7 @@
 # Source this file to deploy the app
 # Set this to TRUE to deploy for pre-release access (password protected)
 # Set this to FALSE to deploy to the public app
-pra <- FALSE
+pra <- TRUE
 
 # Get deployment functions
 source("shiny_app/deployment/deployment_functions.R")

--- a/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
+++ b/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
@@ -15,14 +15,14 @@ tagList(
            p("Please refer to metadata tab for further information on testing policies."),
            ), #fluidRow
 
-  # fluidRow(width = 12,
-  #          tagList(h2("Number and rate of acute hospital admissions due to COVID-19, influenza and RSV (week ending)")),
-  #          linebreaks(1)), #fluidRow
+  fluidRow(width = 12,
+           tagList(h2("Number and rate of acute hospital admissions due to COVID-19, influenza and RSV (week ending)")),
+           linebreaks(1)), #fluidRow
 
   fluidRow(width=12,
-           # box(width = NULL,
-           #     withNavySpinner(dataTableOutput("hosp_adms_intro_table"))),
-           #linebreaks(1),
+           box(width = NULL,
+               withNavySpinner(dataTableOutput("hosp_adms_intro_table"))),
+           linebreaks(1),
            tagList(h2("Number of acute hospital admissions due to COVID-19, influenza and RSV")),
            linebreaks(1)),
 

--- a/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
+++ b/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
@@ -15,14 +15,14 @@ tagList(
            p("Please refer to metadata tab for further information on testing policies."),
            ), #fluidRow
 
-  fluidRow(width = 12,
-           tagList(h2("Number and rate of acute hospital admissions due to COVID-19, influenza and RSV (week ending)")),
-           linebreaks(1)), #fluidRow
+  # fluidRow(width = 12,
+  #          tagList(h2("Number and rate of acute hospital admissions due to COVID-19, influenza and RSV (week ending)")),
+  #          linebreaks(1)), #fluidRow
 
   fluidRow(width=12,
-           box(width = NULL,
-               withNavySpinner(dataTableOutput("hosp_adms_intro_table"))),
-           linebreaks(1),
+           # box(width = NULL,
+           #     withNavySpinner(dataTableOutput("hosp_adms_intro_table"))),
+           #linebreaks(1),
            tagList(h2("Number of acute hospital admissions due to COVID-19, influenza and RSV")),
            linebreaks(1)),
 

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
@@ -32,7 +32,9 @@ tagList(
                                                             label = "Go to glossary",
                                                             icon = icon_no_warning_fn("paper-plane")
                                                             )), 
-                                               p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
+                                               p("Between 22 May and October 2025, Public Health Scotland (PHS) will be",
+                                                 "reporting Scotland level admissions for COVID-19,",
+                                                 "Influenza and RSV, due to low levels of hospital admissions."),
                                                h6("hidden text for padding page")
                                               
                                                ,

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
@@ -8,7 +8,7 @@ tagList(
 
   fluidRow(width = 12,
                   tabPanel("Acute hospital admissions",
-                           tagList(h2("Number of acute COVID-19 admissions to hospital"),
+                           tagList(h2("Number of acute COVID-19 admissions to hospital in Scotland"),
                                    tags$div(class = "headline",
                                             linebreaks(1),
                                             #h3("Weekly totals from last three weeks"),

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
@@ -56,13 +56,13 @@ tagList(
                            ),
 
 
-                                    tagList(h2("Number of acute COVID-19 admissions to hospital by NHS Health Board of treatment; week ending")),
-
-
-                           fluidRow(width=12,
-                                    box(width = NULL,
-                                        withNavySpinner(dataTableOutput("hospital_admissions_hb_table"))),
-                           ),
+                           #          tagList(h2("Number of acute COVID-19 admissions to hospital by NHS Health Board of treatment; week ending")),
+                           # 
+                           # 
+                           # fluidRow(width=12,
+                           #          box(width = NULL,
+                           #              withNavySpinner(dataTableOutput("hospital_admissions_hb_table"))),
+                           # ),
 
                            tagList(h2("Weekly number of acute COVID-19 hospital admissions by deprivation category (SIMD)"))
 

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_ui.R
@@ -31,9 +31,11 @@ tagList(
                                                actionButton("glossary",
                                                             label = "Go to glossary",
                                                             icon = icon_no_warning_fn("paper-plane")
-                                                            ),
+                                                            )), 
+                                               p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
                                                h6("hidden text for padding page")
-                                               )
+                                              
+                                               ,
                                             ),
 
 

--- a/shiny_app/indicators/hospital_occupancy/hospital_occupancy_ui.R
+++ b/shiny_app/indicators/hospital_occupancy/hospital_occupancy_ui.R
@@ -9,7 +9,7 @@ tagList(
 
 #headline values are created in the setup script, occupancy updated to use the weekly HB values, filtered to Scotland
   fluidRow(width = 12,
-           tagList(h2("Number of inpatients with COVID-19 in hospital (seven day average)"),
+           tagList(h2("Number of inpatients with COVID-19 in hospital (seven day average) in Scotland"),
                    tags$div(class = "headline",
                             br(),
 #                            h3(glue("Seven day average hospital occupancy (inpatients) on the Sunday of the latest three weeks available")),
@@ -28,8 +28,12 @@ tagList(
                               color = "navy",
                               icon = icon_no_warning_fn("calendar-week")),
                             h4("*Snapshot as at a Sunday"),
+p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
                             # This text is hidden by css but helps pad the box at the bottom
-                            h6("hidden text for padding page"))),
+                            h6("hidden text for padding page")),
+
+),
+
            linebreaks(1)),
 
   fluidRow(

--- a/shiny_app/indicators/hospital_occupancy/hospital_occupancy_ui.R
+++ b/shiny_app/indicators/hospital_occupancy/hospital_occupancy_ui.R
@@ -53,13 +53,13 @@ tagList(
 
   ), # fluid row
 
-  tagList(h2("Seven day average of inpatients with COVID-19 in hospital by NHS Health Board of treatment; week ending")),
-
-
-  fluidRow(width=12,
-           box(width = NULL,
-               withNavySpinner(dataTableOutput("hospital_occupancy_hb_table"))),
-  ),
+  # tagList(h2("Seven day average of inpatients with COVID-19 in hospital by NHS Health Board of treatment; week ending")),
+  # 
+  # 
+  # fluidRow(width=12,
+  #          box(width = NULL,
+  #              withNavySpinner(dataTableOutput("hospital_occupancy_hb_table"))),
+  # ),
 
   fluidRow(
     br()),

--- a/shiny_app/indicators/introduction/introduction_server.R
+++ b/shiny_app/indicators/introduction/introduction_server.R
@@ -26,7 +26,10 @@ output$introduction_about <- renderUI({
                     p("Please note that release of information involving small numbers carries a risk that individuals could be identified.",
             "We have carefully considered and assessed these risks, taking steps to reduce them as much as possible,",
             "and balancing them with the need to release useful information.",
-            "Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."), 
+            "Between 22 May and October 2025, Public Health Scotland (PHS) will be reporting",
+            "Scotland level admissions for COVID-19, Influenza and RSV, due to low levels of hospital admissions.", 
+            "This approach aligns to the pre-pandemic reporting schedule for respiratory pathogens, which typically follow a",
+            "seasonal pattern with most cases/admissions occurring between October and April/May."), 
           p(glue("This dashboard was last updated on {Deployment_Date} to include data up to {data_recent_date}.")),
           br(),
 

--- a/shiny_app/indicators/introduction/introduction_server.R
+++ b/shiny_app/indicators/introduction/introduction_server.R
@@ -23,9 +23,10 @@ output$introduction_about <- renderUI({
             to severe complications including death."),
           p("This interactive dashboard presents data on viral respiratory diseases in Scotland to support the understanding
             of transmission of infection and NHS service planning and policy."),
-          p("Please note that release of information involving small numbers carries a risk that individuals could be identified.",
+                    p("Please note that release of information involving small numbers carries a risk that individuals could be identified.",
             "We have carefully considered and assessed these risks, taking steps to reduce them as much as possible,",
-            "and balancing them with the need to release useful information."),
+            "and balancing them with the need to release useful information.",
+            "Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."), 
           p(glue("This dashboard was last updated on {Deployment_Date} to include data up to {data_recent_date}.")),
           br(),
 

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
@@ -57,7 +57,9 @@ tagList(
                                         label = "Go to glossary",
                                         icon = icon_no_warning_fn("paper-plane")
                                     )),
-p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
+p("Between 22 May and October 2025, Public Health Scotland (PHS) will be",
+  "reporting Scotland level admissions for COVID-19,",
+  "Influenza and RSV, due to low levels of hospital admissions."),
 
                                                                       # This text is hidden by css but helps pad the box at the bottom
                                      h6("hidden text for padding page")

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
@@ -57,6 +57,8 @@ tagList(
                                         label = "Go to glossary",
                                         icon = icon_no_warning_fn("paper-plane")
                                     )),
+p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
+
                                                                       # This text is hidden by css but helps pad the box at the bottom
                                      h6("hidden text for padding page")
                             )))), # headline

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
@@ -81,16 +81,16 @@ tagList(
     ), # tabBox
     linebreaks(1)
       ), # fluidRow
-fluidRow(width = 12,
-         tagList(h2("Number of acute influenza admissions to hospital by NHS Health Board of Treatment; week ending")),
-         linebreaks(1)), #fluidRow
-
-fluidRow(width=12,
-         box(width = NULL,
-             withNavySpinner(dataTableOutput("flu_admissions_hb_table"))),
-         fluidRow(
-           width=12, linebreaks(1))
-),
+# fluidRow(width = 12,
+#          tagList(h2("Number of acute influenza admissions to hospital by NHS Health Board of Treatment; week ending")),
+#          linebreaks(1)), #fluidRow
+# 
+# fluidRow(width=12,
+#          box(width = NULL,
+#              withNavySpinner(dataTableOutput("flu_admissions_hb_table"))),
+#          fluidRow(
+#            width=12, linebreaks(1))
+# ),
 
 # pyramid sections 
 # 

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_admissions_ui.R
@@ -27,7 +27,7 @@ tagList(
   fluidRow(width = 12,
            tabPanel(stringr::str_to_sentence("influenza"),
                     # headline figures for the week in Scotland
-                    tagList(h2(glue("Number of acute influenza admissions to hospital")),
+                    tagList(h2(glue("Number of acute influenza admissions to hospital in Scotland")),
                             tags$div(class = "headline",
                                      br(),
 #                                     h3(glue("Total number of influenza hospital admissions in Scotland over the last two weeks")),

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
@@ -23,7 +23,7 @@ tagList(
   fluidRow(width = 12,
            tabPanel(stringr::str_to_sentence("influenza"),
                     # headline figures for the week in Scotland
-                    tagList(h2(glue("Number of acute RSV admissions to hospital")),
+                    tagList(h2(glue("Number of acute RSV admissions to hospital in Scotland")),
                             tags$div(class = "headline",
                                      br(),
 #                                     h3(glue("Total number of RSV hospital admissions in Scotland over the last two weeks")),

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
@@ -53,7 +53,9 @@ tagList(
                                      label = "Go to glossary",
                                      icon = icon_no_warning_fn("paper-plane")
                                     )),
-p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
+p("Between 22 May and October 2025, Public Health Scotland (PHS) will be",
+  "reporting Scotland level admissions for COVID-19,",
+  "Influenza and RSV, due to low levels of hospital admissions."),
                                      # This text is hidden by css but helps pad the box at the bottom
                                      h6("hidden text for padding page"),
 

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
@@ -53,9 +53,11 @@ tagList(
                                      label = "Go to glossary",
                                      icon = icon_no_warning_fn("paper-plane")
                                     )),
+p("Due to low levels of hospital admissions for COVID-19, Influenza and RSV, Public Heath Scotland will now only be reporting Scotland level figures until October 2025."),
                                      # This text is hidden by css but helps pad the box at the bottom
-                                     h6("hidden text for padding page")
-                            )))), # headline
+                                     h6("hidden text for padding page"),
+
+                           )))), # headline
 
 #  fluidRow(width = 12,
 #           tagList(h2("Number of acute RSV admissions to hospital"))),

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_admissions_ui.R
@@ -78,16 +78,16 @@ tagList(
     linebreaks(1)
   ), # fluidRow
 # 
-fluidRow(width = 12,
-         tagList(h2("Number of acute RSV admissions to hospital by NHS Health Board of Treatment; week ending")),
-         linebreaks(1)), #fluidRow
-
-fluidRow(width=12,
-         box(width = NULL,
-             withNavySpinner(dataTableOutput("rsv_admissions_hb_table"))),
-         fluidRow(
-           width=12, linebreaks(1))
-),
+# fluidRow(width = 12,
+#          tagList(h2("Number of acute RSV admissions to hospital by NHS Health Board of Treatment; week ending")),
+#          linebreaks(1)), #fluidRow
+# 
+# fluidRow(width=12,
+#          box(width = NULL,
+#              withNavySpinner(dataTableOutput("rsv_admissions_hb_table"))),
+#          fluidRow(
+#            width=12, linebreaks(1))
+# ),
 # pyramid sections 
 # fluidRow(  
 #   

--- a/shiny_app/indicators/syndromic_surveillance/gp/gp_ui.R
+++ b/shiny_app/indicators/syndromic_surveillance/gp/gp_ui.R
@@ -9,9 +9,7 @@ tagList(
              "diagnosis is often referred as Influenza-like Illness (ILI) by General Practitioners",
              "(GP). ILI consultation rates are used internationally as a key measure of influenza",
              "activity in the community and is used to gauge the severity of influenza seasons each winter."),
-            p("Note: Due to technical reasons, GP consulatation data presented below only go up to week 19.",
-             "Investigations are currently ongoing into the cause and complete data will be presented in a future publication."),
-#             "More information on the definition of ILI can be found…"),
+            
            linebreaks(1)),
 
   fluidRow(width = 12,

--- a/shiny_app/indicators/syndromic_surveillance/gp/gp_ui.R
+++ b/shiny_app/indicators/syndromic_surveillance/gp/gp_ui.R
@@ -9,7 +9,7 @@ tagList(
              "diagnosis is often referred as Influenza-like Illness (ILI) by General Practitioners",
              "(GP). ILI consultation rates are used internationally as a key measure of influenza",
              "activity in the community and is used to gauge the severity of influenza seasons each winter."),
-            p("Note: GP consultation data for NHS Ayrshire and Arran are incomplete for the most recent week.",
+            p("Note: Due to technical reasons, GP consulatation data presented below only go up to week 19.",
              "Investigations are currently ongoing into the cause and complete data will be presented in a future publication."),
 #             "More information on the definition of ILI can be found…"),
            linebreaks(1)),


### PR DESCRIPTION
Commented out all the data tables showing breakdown of admissions by board for all pathogens - including occupancy for COVID and the data table in at_a_glance.