### PR TITLE
various transfer fixes

### DIFF
--- a/Dashboard Data Transfer/Transfer Scripts/transfer_occupancy_rapid.R
+++ b/Dashboard Data Transfer/Transfer Scripts/transfer_occupancy_rapid.R
@@ -5,6 +5,31 @@ i_rapid_occupancy <- read_csv_with_options(match_base_filename(glue(input_data, 
 
 write.csv(i_rapid_occupancy, glue(output_folder, "occupancy_rapid.csv"), row.names = FALSE)
 
-rm(i_rapid_occupancy)
+i_hb_occupancy <- read_csv(glue(output_folder, "Occupancy_Weekly_Hospital_HB.csv"))
+
+
+### Make data set with hospital occupancy using manual submissions up to W39 2025
+### Then figures based on RAPID from that point onwards
+i_occupancy_manual <- i_hb_occupancy %>%
+  filter(HealthBoardQF== "d") %>% #filters for Scotland values
+  filter(WeekEnding <= as_date("2025/09/28")) %>% 
+  arrange(desc(WeekEnding_od)) %>% 
+  select(WeekEnding, HospitalOccupancy, SevenDayAverage)
+
+i_occupancy_covid_rapid <- i_rapid_occupancy %>%
+  filter(pathogen == "COVID-19") %>% 
+  filter(week_ending > as_date("2025/09/28")) %>% 
+  arrange(desc(week_ending)) %>% 
+  select(WeekEnding = week_ending,
+         HospitalOccupancy = bed_occupancy,
+         SevenDayAverage= sevenday_ave_inpatients) %>%
+  mutate(WeekEnding = as.Date(WeekEnding))
+
+i_occupancy_covid <- bind_rows(i_occupancy_covid_rapid, i_occupancy_manual)
+
+write.csv(i_occupancy_covid, glue(output_folder, "occupancy_covid.csv"), row.names = FALSE)
+
+
+rm(i_rapid_occupancy, i_hb_occupancy, i_occupancy_manual, i_occupancy_covid_rapid, i_occupancy_covid)
 
 

--- a/Dashboard Data Transfer/Transfer Scripts/transfer_respiratory_admissions.R
+++ b/Dashboard Data Transfer/Transfer Scripts/transfer_respiratory_admissions.R
@@ -1,7 +1,7 @@
-# Dashboard data transfer for RSV hospital admissions data
+# Dashboard data transfer for all pathogen hospital admissions data
 # Sourced from ../dashboard_data_transfer.R
 
-##### RSV
+
 
 #create weekord
 date_reference_ord <-readRDS("/conf/C19_Test_and_Protect/Analyst Space/Calum (Analyst Space)/flu_seasons.Rds") %>%
@@ -18,22 +18,22 @@ date_reference <- readRDS("/conf/C19_Test_and_Protect/Analyst Space/Calum (Analy
   distinct(date, year, ISOweek, flu_season) %>%
   left_join(date_reference_ord)
 
-i_respiratory_admissions <- read_csv_with_options(match_base_filename(glue(input_data, "All_path_admissions.csv")))
+i_respiratory_admissions <- read_csv_with_options(match_base_filename(glue(input_data, "All_path_admissions_by_week_ending.csv")))
 
 
-g_respiratory_admissions <- all_pathogen_admissions %>%
-  # dplyr::rename(Date = date) %>%
-  #  mutate(date = as.Date(Date)) %>%
-  left_join(date_reference, by = c("iso_year" = "year", "iso_week" = "ISOweek")) %>%
+g_respiratory_admissions <- i_respiratory_admissions %>%
+  dplyr::rename(Date = date) %>%
+  mutate(date = as.Date(Date)) %>%
+  left_join(date_reference, by = c("date" = "date", "iso_year" = "year", "iso_week" = "ISOweek")) %>%
   mutate(Date = as_date(ceiling_date(as_date(Date), "week",
                                      change_on_boundary = F))) %>%
-  dplyr::rename(Year = iso_yar,
+  dplyr::rename(Year = iso_year,
                 ISOWeek = iso_week,
                 Season = flu_season)
 
 
 
-write.csv(g_respiratory_admissions, glue(output_folder, "All_path__admissions.csv"), row.names = FALSE)
+write.csv(g_respiratory_admissions, glue(output_folder, "all_pathogen_admissions.csv"), row.names = FALSE)
 
 rm(i_respiratory_admissions, g_respiratory_admissions)
 

--- a/shiny_app/indicators/hospital_occupancy/hospital_occupancy_server.R
+++ b/shiny_app/indicators/hospital_occupancy/hospital_occupancy_server.R
@@ -44,29 +44,6 @@ altTextServer("icu_occupancy_modal",
 )
 
 
-
-
-### Make data table with hospital occupancy using manual submissions up to W39 2025
-### Then figures based on RAPID from that point onwards
-
-occupancy_manual <- Occupancy_Weekly_Hospital_HB %>%
-  filter(HealthBoardQF== "d") %>% #filters for Scotland values
-  filter(WeekEnding <= as_date("2025/09/28")) %>% 
-  arrange(desc(WeekEnding_od)) %>% 
-  select(WeekEnding, HospitalOccupancy, SevenDayAverage)
-
-occupancy_covid <- occupancy_rapid %>%
-  filter(pathogen == "COVID-19") %>% 
-  filter(week_ending > as_date("2025/09/28")) %>% 
-  arrange(desc(week_ending)) %>% 
-  select(WeekEnding = week_ending,
-         HospitalOccupancy = bed_occupancy,
-         SevenDayAverage= sevenday_ave_inpatients) %>%
-  mutate(WeekEnding = as.Date(WeekEnding))
-
-occupancy_covid <- bind_rows(occupancy_covid, occupancy_manual)
-
-
 # Figures for last three weeks
 covid_occupancy_recent_week <- occupancy_covid %>%
   arrange(WeekEnding) %>% 

--- a/shiny_app/indicators/hospital_occupancy/hospital_occupancy_ui.R
+++ b/shiny_app/indicators/hospital_occupancy/hospital_occupancy_ui.R
@@ -1,3 +1,20 @@
+# Figures for last three weeks
+covid_occupancy_recent_week <- occupancy_covid %>%
+  arrange(WeekEnding) %>% 
+  mutate(pathogen = "COVID-19") %>% 
+  tail(3) %>%
+  #select(-Rate_per_100000) %>%
+  pivot_wider(names_from = pathogen,
+              values_from = SevenDayAverage) %>%
+  mutate(DateTwoWeek = .$WeekEnding[1],
+         DateLastWeek = .$WeekEnding[2],
+         DateThisWeek = .$WeekEnding[3],
+         OccupancyTwoWeek = .$`COVID-19`[1],
+         OccupancyLastWeek = .$`COVID-19`[2],
+         OccupancyThisWeek = .$`COVID-19`[3]) %>%
+  select(DateTwoWeek, DateLastWeek, DateThisWeek, OccupancyTwoWeek, OccupancyLastWeek, OccupancyThisWeek) %>%
+  head(1)
+
 tagList(
   fluidRow(width = 12,
            metadataButtonUI("hospital_occupancy"),

--- a/shiny_app/indicators/respiratory_mem/adenovirus/adenovirus_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/adenovirus/adenovirus_admissions_ui.R
@@ -1,7 +1,7 @@
 # Recent weeks admissions
 
 adenovirus_admissions_recent_week <- all_pathogen_admissions %>%
-  mutate(Date = dmy(Date)) %>%
+ # mutate(Date = dmy(Date)) %>%
   tail(3) %>%
   mutate(DateTwoWeek = .$Date[1],
          DateLastWeek = .$Date[2],

--- a/shiny_app/indicators/respiratory_mem/hmpv/hmpv_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/hmpv/hmpv_admissions_ui.R
@@ -1,7 +1,7 @@
 # Recent weeks admissions
 
 hmpv_admissions_recent_week <- all_pathogen_admissions %>%
-  mutate(Date = dmy(Date)) %>%
+ # mutate(Date = dmy(Date)) %>%
   tail(3) %>%
   mutate(DateTwoWeek = .$Date[1],
          DateLastWeek = .$Date[2],

--- a/shiny_app/indicators/respiratory_mem/mycoplasma_pneumoniae/mycoplasma_pneumoniae_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/mycoplasma_pneumoniae/mycoplasma_pneumoniae_admissions_ui.R
@@ -1,7 +1,7 @@
 # Recent weeks admissions
 
 mpn_admissions_recent_week <- all_pathogen_admissions %>%
-  mutate(Date = dmy(Date)) %>%
+ # mutate(Date = dmy(Date)) %>%
   tail(3) %>%
   mutate(DateTwoWeek = .$Date[1],
          DateLastWeek = .$Date[2],

--- a/shiny_app/indicators/respiratory_mem/parainfluenza/parainfluenza_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/parainfluenza/parainfluenza_admissions_ui.R
@@ -1,7 +1,7 @@
 # Recent weeks admissions
 
 para_admissions_recent_week <- all_pathogen_admissions %>%
-  mutate(Date = dmy(Date)) %>%
+ # mutate(Date = dmy(Date)) %>%
   tail(3) %>%
   mutate(DateTwoWeek = .$Date[1],
          DateLastWeek = .$Date[2],

--- a/shiny_app/indicators/respiratory_mem/rhinovirus/rhinovirus_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/rhinovirus/rhinovirus_admissions_ui.R
@@ -1,7 +1,7 @@
 # Recent weeks admissions
 
 rhino_admissions_recent_week <- all_pathogen_admissions %>%
-  mutate(Date = dmy(Date)) %>%
+ # mutate(Date = dmy(Date)) %>%
   tail(3) %>%
   mutate(DateTwoWeek = .$Date[1],
          DateLastWeek = .$Date[2],

--- a/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_admissions_ui.R
+++ b/shiny_app/indicators/respiratory_mem/seasonal_coronavirus/seasonal_coronavirus_admissions_ui.R
@@ -1,7 +1,7 @@
 # Recent weeks admissions
 
 coron_admissions_recent_week <- all_pathogen_admissions %>%
-  mutate(Date = dmy(Date)) %>%
+#  mutate(Date = dmy(Date)) %>%
   tail(3) %>%
   mutate(DateTwoWeek = .$Date[1],
          DateLastWeek = .$Date[2],


### PR DESCRIPTION
Various fixes:
- Creates a combined Covid occupancy dataset (Manual submissions pre W40-2025/RAPID derivation post W40-2025). Was previously done as part of dashboard. Doing it at the transfer stage means it can be picked up for OpenData
- Fixes an issue where the all_pathogen_admissions file wasn't being transferred
- Change so that C19 occupancy headline boxes reads from the combined file
- Date format fix for other pathogen admissions