### PR TITLE
Aag update mh

### DIFF
--- a/Dashboard Data Transfer/Transfer Scripts/transfer_respiratory_test_positivity.R
+++ b/Dashboard Data Transfer/Transfer Scripts/transfer_respiratory_test_positivity.R
@@ -44,4 +44,4 @@ write_csv(Respiratory_test_pos_agg, glue(output_folder, "Respiratory_Pathogens_T
 
 
 # Output to Open Data subfolder with datestamp
-write_csv(Respiratory_test_pos_agg_od, glue(od_folder, "new/", "Respiratory_Pathogens_Test_Positivity_{od_report_date}.csv"))
+#write_csv(Respiratory_test_pos_agg_od, glue(od_folder, "new/", "Respiratory_Pathogens_Test_Positivity_{od_report_date}.csv"))

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -407,7 +407,7 @@ ui <- fluidPage(
       ##############################################.
       # DATA DOWNLOAD ----
       ##############################################.
-      tabPanel(title = "Download data",
+      tabPanel(title = "Open data",
                # Look at https://fontawesome.com/search?m=free for icons
                icon = icon_no_warning_fn("floppy-disk"),
                value = "download",

--- a/shiny_app/indicators/at_a_glance/at_a_glance_server.R
+++ b/shiny_app/indicators/at_a_glance/at_a_glance_server.R
@@ -43,27 +43,40 @@ previous_week_admissions_title <- previous_week_admissions_title$Date
 
 # occupancy labels- (uses weekly covid HB occupancy i.e. same dataframe that produces the table)
 
-latest_week_occupancy_title<- Occupancy_Weekly_Hospital_HB %>%
-     filter(HealthBoardQF== "d") %>%#use weekly value, filter to Scotland
-     tail(1) %>%
-     select(Date=WeekEnding)
-# Convert to the correct format
-latest_week_occupancy_title$Date<- format(latest_week_occupancy_title$Date, "%d %b %y")
+# latest_week_occupancy_title<- Occupancy_Weekly_Hospital_HB %>%
+#      filter(HealthBoardQF== "d") %>%#use weekly value, filter to Scotland
+#      tail(1) %>%
+#      select(Date=WeekEnding)
+# # Convert to the correct format
+# latest_week_occupancy_title$Date<- format(latest_week_occupancy_title$Date, "%d %b %y")
+# 
+# # Convert to the correct format
+# latest_week_occupancy_title<-latest_week_occupancy_title$Date
+# 
+# previous_week_occupancy_title<- Occupancy_Weekly_Hospital_HB %>%
+#      filter(HealthBoardQF== "d") %>%#use weekly value, filter to Scotland
+#      tail(2) %>%
+#      select(Date=WeekEnding) %>%
+#      filter(Date== min(Date))
+# 
+# # Convert to the correct format
+#    previous_week_occupancy_title$Date<- format(previous_week_occupancy_title$Date, "%d %b %y")
+# 
+# # makle it a value
+#    previous_week_occupancy_title<- previous_week_occupancy_title$Date
 
-# Convert to the correct format
-latest_week_occupancy_title<-latest_week_occupancy_title$Date
+latest_week_occupancy_title <- occupancy_rapid %>%
+  tail(1) %>%
+  select(Date) %>%
+  mutate(Date = format(Date, "%d %b %y")) %>%
+  .$Date
 
-previous_week_occupancy_title<- Occupancy_Weekly_Hospital_HB %>%
-     filter(HealthBoardQF== "d") %>%#use weekly value, filter to Scotland
-     tail(2) %>%
-     select(Date=WeekEnding) %>%
-     filter(Date== min(Date))
-
-# Convert to the correct format
-   previous_week_occupancy_title$Date<- format(previous_week_occupancy_title$Date, "%d %b %y")
-
-# makle it a value
-   previous_week_occupancy_title<- previous_week_occupancy_title$Date
+previous_week_occupancy_title <- occupancy_rapid %>%
+  tail(4) %>%
+  select(Date) %>%
+  filter(Date == min(Date)) %>%
+  mutate(Date = format(Date, "%d %b %y")) %>%
+  .$Date
 
 # create value to produce population rate values
 pop_scot_total <- i_population_v2 %>%
@@ -189,18 +202,28 @@ colnames(hosp_adms_intro)[3] <- paste("Rate of admissions per 100,000 population
 # join into one table
 # rename and add week titles for the dashboard
 
-covid_inpatients_intro <- Occupancy_Weekly_Hospital_HB %>%
-  filter(HealthBoardQF== "d") %>%#use weekly value, filter to Scotland
-  tail(2) %>% #last 2 weeks
-  mutate(flag= if_else(WeekEnding_od==max(WeekEnding_od),"Latest Week", "Previous Week")) %>% #add flags
-  select(flag, SevenDayAverage) %>%
-  pivot_wider(names_from = flag, values_from = SevenDayAverage) %>%
-  mutate(Pathogen = "COVID-19") %>%
+# covid_inpatients_intro <- Occupancy_Weekly_Hospital_HB %>%
+#   filter(HealthBoardQF== "d") %>%#use weekly value, filter to Scotland
+#   tail(2) %>% #last 2 weeks
+#   mutate(flag= if_else(WeekEnding_od==max(WeekEnding_od),"Latest Week", "Previous Week")) %>% #add flags
+#   select(flag, SevenDayAverage) %>%
+#   pivot_wider(names_from = flag, values_from = SevenDayAverage) %>%
+#   mutate(Pathogen = "COVID-19") %>%
+#   select(Pathogen, `Previous Week`, `Latest Week`)
+# 
+# colnames(covid_inpatients_intro)[3] <- paste("Seven day average number (", as.character(latest_week_occupancy_title),")")
+# colnames(covid_inpatients_intro)[2] <- paste("Seven day average number (", as.character(previous_week_occupancy_title),")")
+
+inpatients_intro <- occupancy_rapid %>%
+  tail(6) %>%
+  mutate(flag= if_else(Date == max(Date),"Latest Week", "Previous Week")) %>% #add flags
+  select(pathogen, flag, sevenday_ave_inpatients) %>%
+  pivot_wider(names_from = flag, values_from = sevenday_ave_inpatients) %>%
+  rename(Pathogen = pathogen) %>%
   select(Pathogen, `Previous Week`, `Latest Week`)
 
-colnames(covid_inpatients_intro)[3] <- paste("Seven day average number (", as.character(latest_week_occupancy_title),")")
-colnames(covid_inpatients_intro)[2] <- paste("Seven day average number (", as.character(previous_week_occupancy_title),")")
-
+colnames(inpatients_intro)[3] <- paste("Seven day average number (", as.character(latest_week_occupancy_title),")")
+colnames(inpatients_intro)[2] <- paste("Seven day average number (", as.character(previous_week_occupancy_title),")")
 
 ### Data tables -----
 
@@ -220,7 +243,7 @@ output$hosp_adms_intro_table <- renderDataTable({
 
 # Inpatients table
 output$inpatients_intro_table <- renderDataTable({
-  covid_inpatients_intro%>%
+  inpatients_intro%>%
     make_summary_table()
 
 })

--- a/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
+++ b/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
@@ -68,7 +68,8 @@ tagList(
                withNavySpinner(
                  plotlyOutput("hosp_adms_intro_plot")),
            fluidRow(
-             width=12, linebreaks(5)))
+             width=12, 
+             linebreaks(1)))
   ), #fluidRow
 
  fluidRow(width = 12,

--- a/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
+++ b/shiny_app/indicators/at_a_glance/at_a_glance_ui.R
@@ -69,18 +69,18 @@ tagList(
                  plotlyOutput("hosp_adms_intro_plot")),
            fluidRow(
              width=12, linebreaks(5)))
-  )#, #fluidRow
+  ), #fluidRow
 
-  # fluidRow(width = 12,
-  #          tagList(h2("Number of inpatients with COVID-19 in hospital (seven day average)")),
-  #          linebreaks(1)), #fluidRow
-  # 
-  # fluidRow(width=12,
-  #          box(width = NULL,
-  #              withNavySpinner(dataTableOutput("inpatients_intro_table"))),
-  #          fluidRow(
-  #            width=12, linebreaks(5))
- # )
+ fluidRow(width = 12,
+          tagList(h2("Number of inpatients in hospital with COVID-19, Influenza, or RSV (seven day average)")),
+          linebreaks(1)), #fluidRow
+
+ fluidRow(width=12,
+          box(width = NULL,
+              withNavySpinner(dataTableOutput("inpatients_intro_table"))),
+          fluidRow(
+            width=12, linebreaks(5))
+ )
 
 
 

--- a/shiny_app/indicators/download/download_server.R
+++ b/shiny_app/indicators/download/download_server.R
@@ -133,7 +133,7 @@ metadataButtonServer(id="download",
 
 
 output$download_open_data <- renderUI({
-  tagList(h3("Open data"),
+  tagList(#h3("Open data"),
           tags$a(img(src = "open-data-logo.png", height = 30,
                      alt ="Go to Scottish Health and Social Care Open Data platform (external site)"),
                  href = "https://www.opendata.nhs.scot",

--- a/shiny_app/indicators/download/download_ui.R
+++ b/shiny_app/indicators/download/download_ui.R
@@ -4,7 +4,7 @@ tagList(
     fluidRow(width = 12,
              linebreaks(1),
              metadataButtonUI("download"),
-             h1("Download data")),
+             h1("Open data")),
     
     fluidRow(width = 12,
              withNavySpinner(uiOutput("download_open_data")),

--- a/shiny_app/indicators/hospital_admissions/hospital_admissions_functions.R
+++ b/shiny_app/indicators/hospital_admissions/hospital_admissions_functions.R
@@ -101,7 +101,7 @@ make_hospital_admissions_plot <- function(data){
   # Add layout and config
     layout(margin = list(b = 80, t = 5),
                 yaxis = yaxis_plots, xaxis = xaxis_plots,
-           legend = list(xanchor = "center", x = 0.5, y = -0.5, orientation = 'h'),
+           legend = list(xanchor = "center", x = 0.5, y = -0.2, orientation = 'h'),
                 paper_bgcolor = phs_colours("phs-liberty-10"),
                 plot_bgcolor = phs_colours("phs-liberty-10")) %>%
     config(displaylogo = FALSE, displayModeBar = TRUE,

--- a/shiny_app/indicators/hospital_occupancy/hospital_occupancy_functions.R
+++ b/shiny_app/indicators/hospital_occupancy/hospital_occupancy_functions.R
@@ -36,7 +36,7 @@ make_occupancy_plots <- function(data, occupancy) {
                           xs= c("2025-09-28"),
                           notes=c("Inpatient data source changed to RAPID from 28 September 2023"),
                           colors=c(phs_colours("phs-graphite"))) %>% 
-      layout(legend = list(xanchor = "center", x = 0.5, y = -0.5, orientation = 'h'))
+      layout(legend = list(xanchor = "center", x = 0.5, y = -0.2, orientation = 'h'))
 
 
 
@@ -60,7 +60,7 @@ make_occupancy_plots <- function(data, occupancy) {
                  linetype = ~ICULengthOfStay,
                  linetypes = c("dash", "solid")) %>%
       add_trace(type = 'scatter', mode = 'lines') %>%
-      layout(legend = list(xanchor = "center", x = 0.5, y = -0.5, orientation = 'h'))
+      layout(legend = list(xanchor = "center", x = 0.5, y = -0.2, orientation = 'h'))
   }
 
   p <- p %>%

--- a/shiny_app/indicators/introduction/introduction_server.R
+++ b/shiny_app/indicators/introduction/introduction_server.R
@@ -80,7 +80,7 @@ output$introduction_about <- renderUI({
 
           fluidRow(
             column(4,tags$div(class = "special_button",
-                              actionButton("jump_to_download", "Download data"))),
+                              actionButton("jump_to_download", "Open data"))),
             column(8, p("Data pertaining to selected indicators presented in this dashboard can be downloaded as open data."))),
 
           br()

--- a/shiny_app/indicators/respiratory_mem/influenza/influenza_occupancy_ui.R
+++ b/shiny_app/indicators/respiratory_mem/influenza/influenza_occupancy_ui.R
@@ -65,7 +65,7 @@ p("Between 22 May and October 2025, Public Health Scotland (PHS) will be reporti
                             altTextUI("influenza_occupancy_modal"),
                             withNavySpinner(plotlyOutput("influenza_occupancy_plot")),
                             fluidRow(
-                              width=12, linebreaks(4))
+                              width=12, linebreaks(1))
                     ) # taglist
            ), # tabpanel
 

--- a/shiny_app/indicators/respiratory_mem/rsv/rsv_occupancy_ui.R
+++ b/shiny_app/indicators/respiratory_mem/rsv/rsv_occupancy_ui.R
@@ -65,7 +65,7 @@ p("Between 22 May and October 2025, Public Health Scotland (PHS) will be reporti
                             altTextUI("rsv_occupancy_modal"),
                             withNavySpinner(plotlyOutput("rsv_occupancy_plot")),
                             fluidRow(
-                              width=12, linebreaks(4))
+                              width=12, linebreaks(1))
                     ) # taglist
            ), # tabpanel
 

--- a/shiny_app/indicators/wastewater/health_board/hb_server.R
+++ b/shiny_app/indicators/wastewater/health_board/hb_server.R
@@ -45,12 +45,11 @@ output$health_board_plot =  renderPlotly({
                         notes=c("From 01 August 2024, COVID-19 water samples testing transferred<br>from Scottish Environment Protection Agency (SEPA) to NHS Lothian"),
                         colors=c(phs_colours("phs-rust"))) %>%
     layout(title = paste("COVID-19 wastewater viral RNA (Mgc/p/d) for", input$selected_board),
-           xaxis = list(title = "Week Ending Date",
-                        rangeslider = list(type = "date")),
+           xaxis = list(title = "Week Ending Date"),
            yaxis = list(title = "Wastewater viral RNA (Mgc/p/d)"),
            paper_bgcolor = phs_colours("phs-liberty-10"),
            plot_bgcolor = phs_colours("phs-liberty-10"),
-           legend = list(xanchor = "center", x = 0.5, y = -0.75, orientation = 'h')) %>% 
+           legend = list(xanchor = "center", x = 0.5, y = -0.2, orientation = 'h')) %>% 
     
     config(displaylogo = FALSE, displayModeBar = TRUE,
            modeBarButtonsToRemove = bttn_remove)

--- a/shiny_app/indicators/wastewater/local_authority/la_server.R
+++ b/shiny_app/indicators/wastewater/local_authority/la_server.R
@@ -45,12 +45,11 @@ output$council_area_plot =  renderPlotly({
                         notes=c("From 01 August 2024, COVID-19 water samples testing transferred<br>from Scottish Environment Protection Agency (SEPA) to NHS Lothian"),
                         colors=c(phs_colours("phs-rust"))) %>%
     layout(title = paste("COVID-19 wastewater viral RNA (Mgc/p/d) for", input$selected_area),
-           xaxis = list(title = "Week Ending Date",
-                        rangeslider = list(type = "date")),
+           xaxis = list(title = "Week Ending Date"),
            yaxis = list(title = "Wastewater viral RNA (Mgc/p/d)"),
            paper_bgcolor = phs_colours("phs-liberty-10"),
            plot_bgcolor = phs_colours("phs-liberty-10"),
-           legend = list(xanchor = "center", x = 0.5, y = -0.75, orientation = 'h')) %>% 
+           legend = list(xanchor = "center", x = 0.5, y = -0.2, orientation = 'h')) %>% 
     
     config(displaylogo = FALSE, displayModeBar = TRUE,
            modeBarButtonsToRemove = bttn_remove)

--- a/shiny_app/indicators/wastewater/wastewater_functions.R
+++ b/shiny_app/indicators/wastewater/wastewater_functions.R
@@ -35,7 +35,7 @@ make_national_wastewater_plot <- function(data){
            #legend = list(x = 100, y = 0.5),
            paper_bgcolor = phs_colours("phs-liberty-10"),
            plot_bgcolor = phs_colours("phs-liberty-10"),
-           legend = list(xanchor = "center", x = 0.5, y = -0.5, orientation = 'h')) %>%
+           legend = list(xanchor = "center", x = 0.5, y = -0.2, orientation = 'h')) %>%
     
     config(displaylogo = FALSE, displayModeBar = TRUE,
            modeBarButtonsToRemove = bttn_remove)


### PR DESCRIPTION
Several updates:

- added occupancy table for Covid, Flu, and RSV into at a glance
- removed extra space below several charts
- removed slider from HB/LA WW plots
- commented out test positivity output being saved to open data as no longer needed
- changed download data tab to open data